### PR TITLE
Improve FastAPI application metadata

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,7 +4,11 @@ from fastapi import FastAPI, status
 from .data.database import Base, engine
 from .api.v1 import applications, contacts, interviews, pipeline_history
 
-app = FastAPI()
+app = FastAPI(
+    title="Job Search Tracker API",
+    version="1.0.0",
+    description="REST API for managing job applications, contacts, interviews, and pipeline history.",
+)
 
 Base.metadata.create_all(bind=engine)
 


### PR DESCRIPTION
## Summary
- add API title, version, and description to FastAPI app initialization

## Testing
- `cd backend && pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb8346b6448328a48442b747578db9