### PR TITLE
Add tests for applications API utilities

### DIFF
--- a/frontend/src/lib/api/applications.test.ts
+++ b/frontend/src/lib/api/applications.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { patchApplication, updateApplicationStatus } from "./applications";
+import { requestData } from "@/lib/api/http";
+import { client } from "@/client/client.gen";
+
+vi.mock("@/lib/api/http", () => ({
+  requestData: vi.fn(),
+}));
+
+vi.mock("@/client/client.gen", () => ({
+  client: {
+    request: vi.fn(),
+  },
+}));
+
+const mockRequestData = vi.mocked(requestData);
+const mockClient = vi.mocked(client);
+
+describe("applications API", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("patchApplication sends a PATCH request with the provided body", async () => {
+    const id = 123;
+    const body = { company: "Acme" };
+    const mockResponse = { id, ...body };
+    mockRequestData.mockResolvedValue(mockResponse as never);
+
+    const result = await patchApplication(id, body);
+
+    expect(mockRequestData).toHaveBeenCalledWith({
+      method: "PATCH",
+      url: `/api/v1/applications/${id}`,
+      body,
+    });
+    expect(result).toBe(mockResponse);
+  });
+
+  it("updateApplicationStatus patches the pipeline status using the generated client", async () => {
+    const id = 789;
+    const pipeline_status = "applied";
+    const mockResponse = { data: { id, pipeline_status } };
+    mockClient.request.mockResolvedValue(mockResponse as never);
+
+    const result = await updateApplicationStatus({ id, pipeline_status });
+
+    expect(mockClient.request).toHaveBeenCalledWith({
+      method: "PATCH",
+      url: `/api/v1/applications/${id}`,
+      body: { pipeline_status },
+    });
+    expect(result).toBe(mockResponse);
+  });
+});


### PR DESCRIPTION
## Summary
- add a unit test verifying that `patchApplication` issues the expected PATCH request
- cover `updateApplicationStatus` to ensure it uses the generated client with the correct payload

## Testing
- `npm run test` *(fails: existing `formatDateShort` expectation in `src/lib/utils/datetime.test.ts`)*

------
https://chatgpt.com/codex/tasks/task_e_68d449dc67c08328a7d88cf7e4a72bce