### PR TITLE
Add tests and docs for pipeline status helpers

### DIFF
--- a/frontend/src/lib/utils/enums.test.ts
+++ b/frontend/src/lib/utils/enums.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import {
+  PIPELINE_STATUS_LABELS,
+  isPipelineStatus,
+  labelOfPipelineStatus,
+  pipelineStatusOptions,
+} from "./enums";
+
+describe("pipeline status helpers", () => {
+  it("pipelineStatusOptions matches PIPELINE_STATUS_LABELS", () => {
+    const expected = Object.entries(PIPELINE_STATUS_LABELS).map(([value, label]) => ({
+      value,
+      label,
+    }));
+
+    expect(pipelineStatusOptions).toEqual(expected);
+  });
+
+  it("labelOfPipelineStatus returns the matching label", () => {
+    expect(labelOfPipelineStatus("applied")).toBe("Applied");
+  });
+
+  it("isPipelineStatus returns true for valid keys and false otherwise", () => {
+    expect(isPipelineStatus("applied")).toBe(true);
+    expect(isPipelineStatus("not-a-status")).toBe(false);
+  });
+});

--- a/frontend/src/lib/utils/enums.ts
+++ b/frontend/src/lib/utils/enums.ts
@@ -60,9 +60,18 @@ export const PIPELINE_STATUS_LABELS = {
 
 export const pipelineStatusOptions = enumOptions(PIPELINE_STATUS_LABELS);
 
+/**
+ * Returns the human-readable label for a given pipeline status key.
+ * Expects a valid {@link PipelineStatus} string such as "applied".
+ */
 export const labelOfPipelineStatus = (s: PipelineStatus) =>
   PIPELINE_STATUS_LABELS[s];
 
+/**
+ * Type guard that verifies the provided value is a {@link PipelineStatus} key.
+ * Accepts any unknown input and returns `true` only for strings in
+ * {@link PIPELINE_STATUS_LABELS}.
+ */
 export function isPipelineStatus(x: unknown): x is PipelineStatus {
   return typeof x === "string" && x in PIPELINE_STATUS_LABELS;
 }


### PR DESCRIPTION
## Summary
- document the pipeline status label helper and its type guard
- cover pipeline status helpers with vitest happy-path checks

## Testing
- npm test *(fails: formatDateShort timezone-dependent assertion in existing suite)*

------
https://chatgpt.com/codex/tasks/task_e_68d44b29a9588328b2a66fde940d37b7