### PR TITLE
feat: add `pipeline_history.transition_date` field

### DIFF
--- a/backend/app/api/v1/pipeline_history.py
+++ b/backend/app/api/v1/pipeline_history.py
@@ -39,7 +39,7 @@ db_dependency = Annotated[Session, Depends(get_db)]
     summary="List pipeline history for an application",
     description=(
         "Returns the pipeline history entries for an application, ordered by "
-        "`changed_at` descending (most recent first)."
+        "`transition_date` descending (most recent first)."
     ),
 )
 async def list_pipeline_history_for_application(
@@ -56,7 +56,11 @@ async def list_pipeline_history_for_application(
     query = (
         db.query(PipelineHistory)
         .filter(PipelineHistory.application_id == application_id)
-        .order_by(PipelineHistory.changed_at.desc(), PipelineHistory.id.desc())
+        .order_by(
+            PipelineHistory.transition_date.desc(),
+            PipelineHistory.changed_at.desc(),
+            PipelineHistory.id.desc(),
+        )
         .limit(limit)
         .offset(offset)
     )
@@ -134,6 +138,7 @@ async def read_pipeline_histories(
 
     pipeline_histories = (
         query.order_by(
+            PipelineHistory.transition_date.desc(),
             PipelineHistory.changed_at.desc(),
             PipelineHistory.id.desc(),
         )
@@ -191,6 +196,7 @@ async def create_pipeline_history(
         application_id=payload.application_id,
         from_status=payload.from_status,
         to_status=payload.to_status,
+        transition_date=payload.transition_date,
         note=payload.note,
     )
     db.add(new_history)
@@ -205,7 +211,7 @@ async def create_pipeline_history(
     response_model=PipelineHistoryRead,
     status_code=status.HTTP_200_OK,
     summary="Update a pipeline history note",
-    description="Only the `note` field may be updated. Status fields are ignored.",
+    description="Only the `note` and `transition_date` fields may be updated. Status fields are ignored.",
 )
 async def update_pipeline_history(
     db: db_dependency,
@@ -218,7 +224,7 @@ async def update_pipeline_history(
     if pipeline_history is None:
         raise HTTPException(status_code=404, detail="Pipeline history not found")
 
-    # Only note can be updated
+    # Only note and transition_date can be updated
     data = payload.model_dump(exclude_unset=True)
     # Explicitly ignore attempts to change statuses/application link
     data.pop("from_status", None)

--- a/backend/app/models/models.py
+++ b/backend/app/models/models.py
@@ -41,6 +41,7 @@ from sqlalchemy import (
     Text,
     Enum as SqlEnum,
     CheckConstraint,
+    Index,
 )
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
@@ -167,6 +168,7 @@ class PipelineHistory(Base):
 
     Each record captures:
       - When it changed (`changed_at`)
+      - Actual date of change, if different from timestamp for user backdating (`transition_date`)
       - From which status (nullable to handle initial state)
       - To which status
       - Optional human note
@@ -184,6 +186,16 @@ class PipelineHistory(Base):
     changed_at = Column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
+    transition_date = Column(Date, nullable=False, default=func.current_date())
     from_status = Column(SqlEnum(PipelineStatus), nullable=True)
     to_status = Column(SqlEnum(PipelineStatus), nullable=False)
     note = Column(Text)
+
+    __table_args__ = (
+        Index("ix_pipeline_history_appid_changed_at", "application_id", "changed_at"),
+        Index(
+            "ix_pipeline_history_appid_transition_date",
+            "application_id",
+            "transition_date",
+        ),
+    )

--- a/backend/app/schemas/pipeline_history.py
+++ b/backend/app/schemas/pipeline_history.py
@@ -19,7 +19,7 @@ class PipelineHistoryBase(BaseModel):
         description="Target status the application moved into.",
     )
     transition_date: Optional[date] = Field(
-        ...,
+        default=None,
         description="Date the status transition occurred. Time portion is ignored.",
     )
     note: Optional[str] = Field(
@@ -73,12 +73,20 @@ class PipelineHistoryCreateFlat(PipelineHistoryBase):
         ..., description="Application id to attach this history to."
     )
 
+    @field_validator("transition_date")
+    @classmethod
+    def _no_future(cls, v: date | None) -> date | None:
+        if v and v > datetime.now(timezone.utc).date():
+            raise ValueError("transition_date cannot be in the future")
+        return v
+
 
 class PipelineHistoryUpdate(BaseModel):
     """
     Schema for updating a pipeline history record.
 
-    Only `note` and `transition_date` may be updated. Attempts to change status fields are ignored by the router.
+    Only `note` and `transition_date` may be updated. Attempts to change status fields are ignored by the
+    router.
     """
 
     model_config = ConfigDict(

--- a/backend/app/schemas/pipeline_history.py
+++ b/backend/app/schemas/pipeline_history.py
@@ -1,8 +1,8 @@
 """Pydantic schemas for PiplineHistory."""
 
-from datetime import datetime
+from datetime import date, datetime, timezone
 from typing import Optional
-from pydantic import BaseModel, ConfigDict, Field, field_serializer
+from pydantic import BaseModel, ConfigDict, Field, field_serializer, field_validator
 from app.core.enums import PipelineStatus
 from app.core.timeutils import to_z
 
@@ -17,6 +17,10 @@ class PipelineHistoryBase(BaseModel):
     to_status: PipelineStatus = Field(
         ...,
         description="Target status the application moved into.",
+    )
+    transition_date: Optional[date] = Field(
+        ...,
+        description="Date the status transition occurred. Time portion is ignored.",
     )
     note: Optional[str] = Field(
         default=None,
@@ -35,12 +39,20 @@ class PipelineHistoryCreate(PipelineHistoryBase):
         json_schema_extra={
             "example": {
                 "application_id": 42,
+                "transition_date": "2025-09-01",
                 "from_status": PipelineStatus.WILL_APPLY.value,
                 "to_status": PipelineStatus.APPLIED.value,
                 "note": "Applied via company website",
             }
         }
     )
+
+    @field_validator("transition_date")
+    @classmethod
+    def _no_future(cls, v: date | None) -> date | None:
+        if v and v > datetime.now(timezone.utc).date():
+            raise ValueError("transition_date cannot be in the future")
+        return v
 
 
 class PipelineHistoryCreateFlat(PipelineHistoryBase):
@@ -49,6 +61,7 @@ class PipelineHistoryCreateFlat(PipelineHistoryBase):
     model_config = ConfigDict(
         json_schema_extra={
             "example": {
+                "transition_date": "2025-09-01",
                 "from_status": PipelineStatus.WILL_APPLY.value,
                 "to_status": PipelineStatus.APPLIED.value,
                 "note": "Applied via company website",
@@ -65,16 +78,22 @@ class PipelineHistoryUpdate(BaseModel):
     """
     Schema for updating a pipeline history record.
 
-    Only `note` may be updated. Attempts to change status fields are ignored by the router.
+    Only `note` and `transition_date` may be updated. Attempts to change status fields are ignored by the router.
     """
 
     model_config = ConfigDict(
         extra="forbid",
         json_schema_extra={
             "example": {
+                "transition_date": "2025-08-31",
                 "note": "Updating audit trail notes.",
             }
         },
+    )
+
+    transition_date: Optional[date] = Field(
+        default=None,
+        description="Date the status transition occurred. Time portion is ignored.",
     )
 
     note: Optional[str] = Field(
@@ -93,6 +112,7 @@ class PipelineHistoryRead(PipelineHistoryBase):
             "example": {
                 "id": 101,
                 "application_id": 42,
+                "transition_date": "2025-09-01",
                 "from_status": PipelineStatus.APPLIED.value,
                 "to_status": PipelineStatus.STAGE_1.value,
                 "note": "Recruiter screen scheduled",

--- a/backend/app/schemas/pipeline_history.py
+++ b/backend/app/schemas/pipeline_history.py
@@ -85,8 +85,8 @@ class PipelineHistoryUpdate(BaseModel):
     """
     Schema for updating a pipeline history record.
 
-    Only `note` and `transition_date` may be updated. Attempts to change status fields are ignored by the
-    router.
+    Only `note` and `transition_date` may be updated. Attempts to change status fields
+    are ignored by the router.
     """
 
     model_config = ConfigDict(

--- a/backend/app/services/applications_service.py
+++ b/backend/app/services/applications_service.py
@@ -10,8 +10,8 @@ so routers stay thin and the audit trail remains correct.
 """
 
 from typing import Optional
+from datetime import datetime, timezone
 from sqlalchemy.orm import Session, selectinload
-
 from app.models.models import Applications, PipelineHistory
 from app.schemas.applications import ApplicationCreate, ApplicationUpdate
 
@@ -52,6 +52,7 @@ def create_application_with_history(
     db.add(
         PipelineHistory(
             application_id=application.id,
+            transition_date=datetime.now(timezone.utc),
             from_status=None,
             to_status=application.pipeline_status,
             note=None,
@@ -89,6 +90,7 @@ def update_application_with_history(
         db.add(
             PipelineHistory(
                 application_id=application_id,
+                transition_date=datetime.now(timezone.utc),
                 from_status=before_status,
                 to_status=application.pipeline_status,
                 note=None,

--- a/backend/app/services/applications_service.py
+++ b/backend/app/services/applications_service.py
@@ -52,7 +52,7 @@ def create_application_with_history(
     db.add(
         PipelineHistory(
             application_id=application.id,
-            transition_date=datetime.now(timezone.utc),
+            transition_date=datetime.now(timezone.utc).date(),
             from_status=None,
             to_status=application.pipeline_status,
             note=None,
@@ -90,7 +90,7 @@ def update_application_with_history(
         db.add(
             PipelineHistory(
                 application_id=application_id,
-                transition_date=datetime.now(timezone.utc),
+                transition_date=datetime.now(timezone.utc).date(),
                 from_status=before_status,
                 to_status=application.pipeline_status,
                 note=None,

--- a/backend/tests/api/v1/test_pipeline_history.py
+++ b/backend/tests/api/v1/test_pipeline_history.py
@@ -6,12 +6,17 @@ from app.core.enums import PipelineStatus
 
 
 def _new_history_payload(
-    to_status=PipelineStatus.APPLIED.value, from_status=None, note="moved"
+    transition_date=None,
+    to_status=PipelineStatus.APPLIED.value,
+    from_status=None,
+    note="moved",
 ):
     """Helper: build a minimal payload for creation endpoints."""
     payload = {"to_status": to_status, "note": note}
     if from_status is not None:
         payload["from_status"] = from_status
+    if transition_date is not None:
+        payload["transition_date"] = transition_date
     return payload
 
 
@@ -36,6 +41,7 @@ def test_create_pipeline_history_nested_returns_read(client, make_application):
     assert body["from_status"] == PipelineStatus.WILL_APPLY.value
     assert body["note"] == "Applied via site"
     assert "changed_at" in body
+    assert "transition_date" in body
 
 
 def test_create_pipeline_history_nested_missing_app_returns_404(client):

--- a/frontend/src/client/@tanstack/react-query.gen.ts
+++ b/frontend/src/client/@tanstack/react-query.gen.ts
@@ -987,7 +987,7 @@ export const listPipelineHistoryForApplicationApiV1ApplicationsApplicationIdPipe
 
 /**
  * List pipeline history for an application
- * Returns the pipeline history entries for an application, ordered by `changed_at` descending (most recent first).
+ * Returns the pipeline history entries for an application, ordered by `transition_date` descending (most recent first).
  */
 export const listPipelineHistoryForApplicationApiV1ApplicationsApplicationIdPipelineHistoryGetOptions =
   (
@@ -1027,7 +1027,7 @@ export const listPipelineHistoryForApplicationApiV1ApplicationsApplicationIdPipe
 
 /**
  * List pipeline history for an application
- * Returns the pipeline history entries for an application, ordered by `changed_at` descending (most recent first).
+ * Returns the pipeline history entries for an application, ordered by `transition_date` descending (most recent first).
  */
 export const listPipelineHistoryForApplicationApiV1ApplicationsApplicationIdPipelineHistoryGetInfiniteOptions =
   (
@@ -1292,7 +1292,7 @@ export const readPipelineHistoryApiV1PipelineHistoryHistoryIdGetOptions = (
 
 /**
  * Update a pipeline history note
- * Only the `note` field may be updated. Status fields are ignored.
+ * Only the `note` and `transition_date` fields may be updated. Status fields are ignored.
  */
 export const updatePipelineHistoryApiV1PipelineHistoryHistoryIdPatchMutation = (
   options?: Partial<

--- a/frontend/src/client/sdk.gen.ts
+++ b/frontend/src/client/sdk.gen.ts
@@ -529,7 +529,7 @@ export const updateInterviewApiV1InterviewsInterviewIdPatch = <
 
 /**
  * List pipeline history for an application
- * Returns the pipeline history entries for an application, ordered by `changed_at` descending (most recent first).
+ * Returns the pipeline history entries for an application, ordered by `transition_date` descending (most recent first).
  */
 export const listPipelineHistoryForApplicationApiV1ApplicationsApplicationIdPipelineHistoryGet =
   <ThrowOnError extends boolean = false>(
@@ -667,7 +667,7 @@ export const readPipelineHistoryApiV1PipelineHistoryHistoryIdGet = <
 
 /**
  * Update a pipeline history note
- * Only the `note` field may be updated. Status fields are ignored.
+ * Only the `note` and `transition_date` fields may be updated. Status fields are ignored.
  */
 export const updatePipelineHistoryApiV1PipelineHistoryHistoryIdPatch = <
   ThrowOnError extends boolean = false,

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -467,6 +467,11 @@ export type PipelineHistoryCreate = {
    */
   to_status: PipelineStatus;
   /**
+   * Transition Date
+   * Date the status transition occurred. Time portion is ignored.
+   */
+  transition_date: string | null;
+  /**
    * Note
    * Optional human note describing the change.
    */
@@ -486,6 +491,11 @@ export type PipelineHistoryCreateFlat = {
    * Target status the application moved into.
    */
   to_status: PipelineStatus;
+  /**
+   * Transition Date
+   * Date the status transition occurred. Time portion is ignored.
+   */
+  transition_date: string | null;
   /**
    * Note
    * Optional human note describing the change.
@@ -512,6 +522,11 @@ export type PipelineHistoryRead = {
    */
   to_status: PipelineStatus;
   /**
+   * Transition Date
+   * Date the status transition occurred. Time portion is ignored.
+   */
+  transition_date: string | null;
+  /**
    * Note
    * Optional human note describing the change.
    */
@@ -534,9 +549,14 @@ export type PipelineHistoryRead = {
  * PipelineHistoryUpdate
  * Schema for updating a pipeline history record.
  *
- * Only `note` may be updated. Attempts to change status fields are ignored by the router.
+ * Only `note` and `transition_date` may be updated. Attempts to change status fields are ignored by the router.
  */
 export type PipelineHistoryUpdate = {
+  /**
+   * Transition Date
+   * Date the status transition occurred. Time portion is ignored.
+   */
+  transition_date?: string | null;
   /**
    * Note
    * New note. If omitted, note remains unchanged.

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -470,7 +470,7 @@ export type PipelineHistoryCreate = {
    * Transition Date
    * Date the status transition occurred. Time portion is ignored.
    */
-  transition_date: string | null;
+  transition_date?: string | null;
   /**
    * Note
    * Optional human note describing the change.
@@ -495,7 +495,7 @@ export type PipelineHistoryCreateFlat = {
    * Transition Date
    * Date the status transition occurred. Time portion is ignored.
    */
-  transition_date: string | null;
+  transition_date?: string | null;
   /**
    * Note
    * Optional human note describing the change.
@@ -525,7 +525,7 @@ export type PipelineHistoryRead = {
    * Transition Date
    * Date the status transition occurred. Time portion is ignored.
    */
-  transition_date: string | null;
+  transition_date?: string | null;
   /**
    * Note
    * Optional human note describing the change.
@@ -549,7 +549,8 @@ export type PipelineHistoryRead = {
  * PipelineHistoryUpdate
  * Schema for updating a pipeline history record.
  *
- * Only `note` and `transition_date` may be updated. Attempts to change status fields are ignored by the router.
+ * Only `note` and `transition_date` may be updated. Attempts to change status fields are ignored by the
+ * router.
  */
 export type PipelineHistoryUpdate = {
   /**


### PR DESCRIPTION
## Summary

This pull request introduces a new `transition_date` field to the `PipelineHistory` model, allowing users to specify the actual date a status transition occurred (which may differ from the automatic timestamp). The change is reflected across the backend (models, schemas, services, and API), as well as the frontend types and API documentation. Additionally, ordering of pipeline history queries now prioritizes `transition_date`. Validation ensures that `transition_date` cannot be set in the future.

**Backend model and schema changes:**

* Added a `transition_date` field (date only) to the `PipelineHistory` database model, with appropriate indexes and documentation. (`backend/app/models/models.py`) [[1]](diffhunk://#diff-3cb714356d7488f592ce85fc131d497352b6e10722986ebc649b553cc37bc78aR171) [[2]](diffhunk://#diff-3cb714356d7488f592ce85fc131d497352b6e10722986ebc649b553cc37bc78aR189-R201)
* Updated Pydantic schemas to include `transition_date` for create, update, and read operations, with validation to disallow future dates. (`backend/app/schemas/pipeline_history.py`) [[1]](diffhunk://#diff-92a1a6713526d3d03c1fc36cad3f742b6da4fd15be364a27869ae68149a8aadeR21-R24) [[2]](diffhunk://#diff-92a1a6713526d3d03c1fc36cad3f742b6da4fd15be364a27869ae68149a8aadeR42-R64) [[3]](diffhunk://#diff-92a1a6713526d3d03c1fc36cad3f742b6da4fd15be364a27869ae68149a8aadeR76-R106) [[4]](diffhunk://#diff-92a1a6713526d3d03c1fc36cad3f742b6da4fd15be364a27869ae68149a8aadeR123)

**API and service logic:**

* Modified API endpoints and service functions to accept, store, and update `transition_date` when creating or updating pipeline history records. (`backend/app/api/v1/pipeline_history.py`, `backend/app/services/applications_service.py`) [[1]](diffhunk://#diff-4eb626159c212bf8b4df6c006dc627f79a4218d38bf6f3151b0068243b353f68R199) [[2]](diffhunk://#diff-4eb626159c212bf8b4df6c006dc627f79a4218d38bf6f3151b0068243b353f68L208-R214) [[3]](diffhunk://#diff-4eb626159c212bf8b4df6c006dc627f79a4218d38bf6f3151b0068243b353f68L221-R227) [[4]](diffhunk://#diff-b5d63a0b38fcb56a4244a407feac6e0629ceeda5fbe3634df1370e91e49e4d3dR55) [[5]](diffhunk://#diff-b5d63a0b38fcb56a4244a407feac6e0629ceeda5fbe3634df1370e91e49e4d3dR93)
* Changed API documentation and descriptions to reflect that both `note` and `transition_date` are updatable. [[1]](diffhunk://#diff-4eb626159c212bf8b4df6c006dc627f79a4218d38bf6f3151b0068243b353f68L208-R214) [[2]](diffhunk://#diff-87930200fba05848fa54972b6ffdadfc48bee76ca9187b9d1bc708bc9662b760L1295-R1295) [[3]](diffhunk://#diff-56402af201e2d6f4a34358957747346c3b3b4016d45d7481c92134e667358e07L670-R670) [[4]](diffhunk://#diff-f78ebe8ae8267386fcb5a50adf07399bd087710aafbc46cea9e110da405f9d69L537-R560)

**Query and ordering updates:**

* Updated all relevant queries to order pipeline history by `transition_date` (descending), then `changed_at`, then `id`. [[1]](diffhunk://#diff-4eb626159c212bf8b4df6c006dc627f79a4218d38bf6f3151b0068243b353f68L42-R42) [[2]](diffhunk://#diff-4eb626159c212bf8b4df6c006dc627f79a4218d38bf6f3151b0068243b353f68L59-R63) [[3]](diffhunk://#diff-4eb626159c212bf8b4df6c006dc627f79a4218d38bf6f3151b0068243b353f68R141) [[4]](diffhunk://#diff-87930200fba05848fa54972b6ffdadfc48bee76ca9187b9d1bc708bc9662b760L990-R990) [[5]](diffhunk://#diff-87930200fba05848fa54972b6ffdadfc48bee76ca9187b9d1bc708bc9662b760L1030-R1030) [[6]](diffhunk://#diff-56402af201e2d6f4a34358957747346c3b3b4016d45d7481c92134e667358e07L532-R532)

**Frontend type and API updates:**

* Extended frontend types and API client code to include the new `transition_date` field in all relevant pipeline history interfaces. (`frontend/src/client/types.gen.ts`, `frontend/src/client/@tanstack/react-query.gen.ts`, `frontend/src/client/sdk.gen.ts`) [[1]](diffhunk://#diff-f78ebe8ae8267386fcb5a50adf07399bd087710aafbc46cea9e110da405f9d69R469-R473) [[2]](diffhunk://#diff-f78ebe8ae8267386fcb5a50adf07399bd087710aafbc46cea9e110da405f9d69R494-R498) [[3]](diffhunk://#diff-f78ebe8ae8267386fcb5a50adf07399bd087710aafbc46cea9e110da405f9d69R524-R528)

**Testing:**

* Updated test helpers and assertions to include and verify the presence of `transition_date` in test payloads and responses. (`backend/tests/api/v1/test_pipeline_history.py`) [[1]](diffhunk://#diff-3e4ded98e292930b461cae8b974e91947b56f1177ecf7c716fa44c3e70086eb5L9-R19) [[2]](diffhunk://#diff-3e4ded98e292930b461cae8b974e91947b56f1177ecf7c716fa44c3e70086eb5R44)