### PR TITLE
fix contact form jank

### DIFF
--- a/frontend/src/components/contacts/ContactCard.tsx
+++ b/frontend/src/components/contacts/ContactCard.tsx
@@ -23,11 +23,11 @@ function buildDiff(original: ContactRead, values: ContactFormValues) {
     phone: emptyToNull(values.phone),
     url: emptyToNull(values.url),
     notes: emptyToNull(values.notes),
-  } as const;
+  };
 
   const diff: Record<string, unknown> = {};
   (Object.keys(next) as (keyof typeof next)[]).forEach((k) => {
-    const was = (original as any)[k] ?? null;
+    const was = original[k as keyof ContactRead] ?? null;
     const now = next[k] ?? null;
     if (was !== now) diff[k] = now;
   });

--- a/frontend/src/components/contacts/ContactCard.tsx
+++ b/frontend/src/components/contacts/ContactCard.tsx
@@ -10,9 +10,8 @@ import {
   ConfirmDeleteButton,
 } from "@/components/contacts/ConfirmActions";
 import type { ContactFormValues } from "@/lib/api/contacts";
-import { displayUrl } from "@/lib/utils/text-helpers";
+import { displayUrl, emptyToNull } from "@/lib/utils/text-helpers";
 import { formatPhonePretty } from "@/lib/utils/phone-numbers";
-import { emptyToNull } from "@/lib/utils/text-helpers";
 
 function buildDiff(original: ContactRead, values: ContactFormValues) {
   const next = {
@@ -24,16 +23,29 @@ function buildDiff(original: ContactRead, values: ContactFormValues) {
     phone: emptyToNull(values.phone),
     url: emptyToNull(values.url),
     notes: emptyToNull(values.notes),
-  };
+  } as const;
 
   const diff: Record<string, unknown> = {};
   (Object.keys(next) as (keyof typeof next)[]).forEach((k) => {
-    const was = original[k as keyof ContactRead] ?? null;
+    const was = (original as any)[k] ?? null;
     const now = next[k] ?? null;
     if (was !== now) diff[k] = now;
   });
   return diff;
 }
+
+type Props = {
+  contact: ContactRead;
+  disabled?: boolean;
+  onEdit: (patch: Record<string, unknown>) => void;
+  onUnlink: () => void;
+  onDelete: () => void;
+
+  /** Optional controlled edit mode props (useful to make the card span full width from the parent) */
+  isEditing?: boolean;
+  onEditStart?: () => void;
+  onCancelEdit?: () => void;
+};
 
 export default function ContactCard({
   contact,
@@ -41,14 +53,23 @@ export default function ContactCard({
   onEdit,
   onUnlink,
   onDelete,
-}: {
-  contact: ContactRead;
-  disabled?: boolean;
-  onEdit: (patch: Record<string, unknown>) => void;
-  onUnlink: () => void;
-  onDelete: () => void;
-}) {
-  const [editing, setEditing] = React.useState(false);
+  isEditing,
+  onEditStart,
+  onCancelEdit,
+}: Props) {
+  // If `isEditing` is provided, we are controlled; otherwise manage local state.
+  const controlled = typeof isEditing === "boolean";
+  const [localEditing, setLocalEditing] = React.useState(false);
+  const editing = controlled ? (isEditing as boolean) : localEditing;
+
+  const startEdit = () => {
+    if (onEditStart) onEditStart();
+    else setLocalEditing(true);
+  };
+  const cancelEdit = () => {
+    if (onCancelEdit) onCancelEdit();
+    else setLocalEditing(false);
+  };
 
   if (editing) {
     const initial: ContactFormValues = {
@@ -72,15 +93,16 @@ export default function ContactCard({
             initial={initial}
             disabled={disabled}
             submitLabel="Save"
-            onCancel={() => setEditing(false)}
+            onCancel={cancelEdit}
             onSubmit={(values) => {
               const diff = buildDiff(contact, values);
               if (Object.keys(diff).length === 0) {
-                setEditing(false);
+                cancelEdit();
                 return;
               }
               onEdit(diff);
-              setEditing(false);
+              // If uncontrolled, close immediately; if controlled, the parent will close on success.
+              if (!controlled) cancelEdit();
             }}
           />
         </CardContent>
@@ -97,7 +119,7 @@ export default function ContactCard({
             <Button
               variant="outline"
               size="sm"
-              onClick={() => setEditing(true)}
+              onClick={startEdit}
               disabled={disabled}
             >
               Edit

--- a/frontend/src/components/contacts/ContactsShow.tsx
+++ b/frontend/src/components/contacts/ContactsShow.tsx
@@ -47,6 +47,8 @@ export default function ContactsShow({ appId }: ContactShowProps) {
   const destroy = useDeleteContact(appId);
 
   const [open, setOpen] = React.useState(false);
+  const [editingId, setEditingId] = React.useState<number | null>(null);
+
   const anyPending =
     create.isPending ||
     update.isPending ||
@@ -115,30 +117,33 @@ export default function ContactsShow({ appId }: ContactShowProps) {
       </div>
 
       <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-        {(contacts ?? []).map((c: ContactRead) => (
-          <ContactCard
-            key={c.id}
-            contact={c}
-            disabled={anyPending}
-            onEdit={(patch) =>
-              update.mutate({
-                path: { contact_id: c.id },
-                body: patch,
-              })
-            }
-            onUnlink={() =>
-              unlink.mutate({
-                path: { contact_id: c.id },
-                body: { application_ids_remove: [appId] },
-              })
-            }
-            onDelete={() =>
-              destroy.mutate({
-                path: { contact_id: c.id },
-              })
-            }
-          />
-        ))}
+        {(contacts ?? []).map((c: ContactRead) => {
+          const isEditing = editingId === c.id;
+          return (
+            <div key={c.id} className={isEditing ? "col-span-full" : undefined}>
+              <ContactCard
+                contact={c}
+                disabled={anyPending}
+                isEditing={isEditing}
+                onEditStart={() => setEditingId(c.id)}
+                onCancelEdit={() => setEditingId(null)}
+                onEdit={(patch) =>
+                  update.mutate(
+                    { path: { contact_id: c.id }, body: patch },
+                    { onSuccess: () => setEditingId(null) },
+                  )
+                }
+                onUnlink={() =>
+                  unlink.mutate({
+                    path: { contact_id: c.id },
+                    body: { application_ids_remove: [appId] },
+                  })
+                }
+                onDelete={() => destroy.mutate({ path: { contact_id: c.id } })}
+              />
+            </div>
+          );
+        })}
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary

This pull request refactors the `ContactCard` component to support both controlled and uncontrolled edit modes, allowing parent components to manage the editing state if desired. It also updates the `ContactsShow` component to use this new controlled mode, enabling only one contact card to be edited at a time and allowing the card to span the full width when in edit mode.

**ContactCard component improvements:**

* Refactored `ContactCard` to accept new optional props (`isEditing`, `onEditStart`, `onCancelEdit`), enabling controlled edit state from the parent and allowing the card to support both controlled and uncontrolled edit modes.
* Updated edit button and form actions to use the new controlled/uncontrolled logic, delegating state changes to parent handlers when in controlled mode. [[1]](diffhunk://#diff-77a482b702248e5ab2b966062adce09375055ee2feefe0707666092dbf2ff9cbL75-R105) [[2]](diffhunk://#diff-77a482b702248e5ab2b966062adce09375055ee2feefe0707666092dbf2ff9cbL100-R122)

**ContactsShow component improvements:**

* Introduced local `editingId` state to track which contact is being edited, ensuring only one card is editable at a time.
* Updated the rendering logic to pass controlled editing props to each `ContactCard`, making the edited card span the full width and closing the edit mode on successful update.

**Code cleanup:**

* Cleaned up imports in `ContactCard.tsx` for better organization.